### PR TITLE
Updated to v7.2 (changelog in comments)

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ The downgrader is "signed", and can be launched without having a custom firmware
 
 ## Changelog
 ### Version 7.1
-* Added experimental support for 07g units.
+* Added experimental support for 07g units on 6.6x.
 ### Version 7.0
 * Added support for Infinity.
 ### Version 6.1

--- a/README.md
+++ b/README.md
@@ -10,7 +10,8 @@ The downgrader is "signed", and can be launched without having a custom firmware
 
 ## Changelog
 ### Version 7.2
-* Removed 'factory firmware limitation', which prevented certain PSPs from being downgradable at all or limited them from being downgraded to certain firmwares they theoretically support.
+* Replaced 'factory firmware limitation', which prevented certain PSPs from being downgradable at all or limited them from being downgraded to certain firmwares they theoretically support.
+* This fixes most cases where an IDXFFFFFFFF or CAAFFFFFCF7 error could appear.
 * Chronoswitch now detects your PSP's motherboard alongside its model and allows flashing all firmwares (5.00+) that are supported by it.
 * Removed support for downgrading 09g units below 6.30.
 ### Version 7.1

--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ The downgrader is "signed", and can be launched without having a custom firmware
 * Silverspring
 * Bubbletune
 * qwikrazor87
+* The Zett
 
 ## Socials
 Follow me on Twitter [@DaveeFTW](https://twitter.com/DaveeFTW), and check out [my blog](https://lolhax.org).

--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ The downgrader is "signed", and can be launched without having a custom firmware
 ### Version 7.2
 * Removed 'factory firmware limitation', which prevented certain PSPs from being downgradable at all or limited them from being downgraded to certain firmwares they theoretically support.
 * Chronoswitch now detects your PSP's motherboard alongside its model and allows flashing all firmwares (5.00+) that are supported by it.
+* Removed support for downgrading 09g units below 6.30.
 ### Version 7.1
 * Added experimental support for 07g units on 6.6x.
 ### Version 7.0

--- a/README.md
+++ b/README.md
@@ -9,6 +9,9 @@ Copy the official firmware update to `PSP/GAME/UPDATE/EBOOT.PBP` on your memory 
 The downgrader is "signed", and can be launched without having a custom firmware installed. Once you run the application, follow the on-screen instructions.
 
 ## Changelog
+### Version 7.2
+* Removed 'factory firmware limitation', which prevented certain PSPs from being downgradable at all or limited them from being downgraded to certain firmwares they theoretically support.
+* Chronoswitch now detects your PSP's motherboard alongside its model and allows flashing all firmwares (5.00+) that are supported by it.
 ### Version 7.1
 * Added experimental support for 07g units on 6.6x.
 ### Version 7.0

--- a/README.md
+++ b/README.md
@@ -2,13 +2,15 @@
 Chronoswitch is a downgrader for the Playstation Portable (PSP).
 
 ## Installation
-Download and extract the latest version from the releases on this github page. Copy the `PSP` folder from the extracted output to your memory stick. You will need the firmware update for version you wish to downgrade to. If you want to downgrade to 6.20, you will need the 6.20 official update. If you're downgrading a PSPgo, make sure you download the official firmware appropriate for that device.
+Download and extract the latest version from the releases on this github page. Copy the `PSP` folder from the extracted output to your memory stick. You will need the firmware update for version you wish to downgrade to. If you want to downgrade to 6.60, you will need the 6.60 official update. If you're downgrading a PSPgo, make sure you download the official firmware appropriate for that device.
 
 Copy the official firmware update to `PSP/GAME/UPDATE/EBOOT.PBP` on your memory stick. If you're using a PSPgo, make sure this copied to the internal storage instead.
 
 The downgrader is "signed", and can be launched without having a custom firmware installed. Once you run the application, follow the on-screen instructions.
 
 ## Changelog
+### Version 7.1
+* Added experimental support for 07g units.
 ### Version 7.0
 * Added support for Infinity.
 ### Version 6.1

--- a/src/Makefile.signed
+++ b/src/Makefile.signed
@@ -19,7 +19,7 @@ LIBS = -lpsppower
 PSP_FW_VERSION = 271
 
 EXTRA_TARGETS = EBOOT.PBP
-PSP_EBOOT_TITLE = Chronoswitch Downgrader v7.1
+PSP_EBOOT_TITLE = Chronoswitch Downgrader v7.2
 
 BUILD_PRX = 1
 

--- a/src/Makefile.signed
+++ b/src/Makefile.signed
@@ -19,7 +19,7 @@ LIBS = -lpsppower
 PSP_FW_VERSION = 271
 
 EXTRA_TARGETS = EBOOT.PBP
-PSP_EBOOT_TITLE = Chronoswitch Downgrader
+PSP_EBOOT_TITLE = Chronoswitch Downgrader v7.1
 
 BUILD_PRX = 1
 

--- a/src/downgrade660_ctrl/main.c
+++ b/src/downgrade660_ctrl/main.c
@@ -138,24 +138,16 @@ int ApplyFirmware(SceModule2 *mod)
 	}
 	else
 	{
-		/* convert to hex */
+		/* convert to hex */		
 		min_ver = (((device_fw_ver[0] - '0') & 0xF) << 8) | (((device_fw_ver[2] - '0') & 0xF) << 4) | (((device_fw_ver[3] - '0') & 0xF) << 0);
 	}
 	
 	/* set the result to 0 */
 	res = 0;
 	
-	/* check if the updater is less than the minimum version */
-	if (updater_ver < min_ver)
-	{
-		/* ok, check for 6.35 and 09g */
-		if ((min_ver != 0x630 && min_ver != 0x635) || sceKernelGetModel() != 8)
-		{
-			/* error */
-			pspSdkSetK1(k1);
-			return -5;
-		}
-		
+	/* check if the updater is 620 and the model is 09g */
+	if (updater_ver == 0x620 && sceKernelGetModel() == 8)
+	{		
 		/* set result to 1 D: */
 		res = 1;
 	}
@@ -281,7 +273,7 @@ int OnModuleStart(SceModule2 *mod)
 		/* check for success */
 		if (res >= 0)
 		{
-			/* do these patches if we have 09g going to 6.XX */
+			/* do these patches if we have 09g going to <6.3X */
 			if (res == 1)
 			{
 				/* patch the IO */

--- a/src/downgrade660_ctrl/main.c
+++ b/src/downgrade660_ctrl/main.c
@@ -125,15 +125,8 @@ int ApplyFirmware(SceModule2 *mod)
 	
 	/* check for error */
 	if (res < 0)
-	{
-		/* check model */
-		if (sceKernelGetModel() != 0)
-		{
-			/* invalid error */
-			return -4;
-		}
-		
-		/* firmware 1.00 */
+	{		
+		/* set minimum firmware to 1.00, if unknown */
 		min_ver = 0x100;
 	}
 	else

--- a/src/downgrade_ctrl/main.c
+++ b/src/downgrade_ctrl/main.c
@@ -125,15 +125,8 @@ int ApplyFirmware(void)
 	
 	/* check for error */
 	if (res < 0)
-	{
-		/* check model */
-		if (sceKernelGetModel() != 0)
-		{
-			/* invalid error */
-			return -4;
-		}
-		
-		/* firmware 1.00 */
+	{		
+		/* set minimum firmware to 1.00, if unknown */
 		min_ver = 0x100;
 	}
 	else
@@ -144,13 +137,13 @@ int ApplyFirmware(void)
 	
 	/* set the result to 0 */
 	res = 0;
-		
+	
 	/* check if the updater is 620 and the model is 09g */
 	if (updater_ver == 0x620 && sceKernelGetModel() == 8)
 	{		
 		/* set result to 1 D: */
 		res = 1;
-	}
+	}	
 
 	/* do spoof! */
 	g_spoof_ver = updater_ver;

--- a/src/downgrade_ctrl/main.c
+++ b/src/downgrade_ctrl/main.c
@@ -139,23 +139,15 @@ int ApplyFirmware(void)
 	else
 	{
 		/* convert to hex */
-		min_ver = (((device_fw_ver[0] - '0') & 0xF) << 8) | (((device_fw_ver[2] - '0') & 0xF) << 4) | (((device_fw_ver[3] - '0') & 0xF) << 0);
+		min_ver = (((device_fw_ver[0] - '0') & 0xF) << 8) | (((device_fw_ver[2] - '0') & 0xF) << 4) | (((device_fw_ver[3] - '0') & 0xF) << 0);		
 	}
 	
 	/* set the result to 0 */
 	res = 0;
-	
-	/* check if the updater is less than the minimum version */
-	if (updater_ver < min_ver)
-	{
-		/* ok, check for 6.35 and 09g */
-		if ((min_ver != 0x630 && min_ver != 0x635) || sceKernelGetModel() != 8)
-		{
-			/* error */
-			pspSdkSetK1(k1);
-			return -5;
-		}
 		
+	/* check if the updater is 620 and the model is 09g */
+	if (updater_ver == 0x620 && sceKernelGetModel() == 8)
+	{		
 		/* set result to 1 D: */
 		res = 1;
 	}
@@ -268,7 +260,7 @@ int OnModuleStart(SceModule *mod)
 		/* check for success */
 		if (res >= 0)
 		{
-			/* do these patches if we have 09g going to 6.XX */
+			/* do these patches if we have 09g going to <6.3X */
 			if (res == 1)
 			{
 				/* patch the IO */

--- a/src/main.c
+++ b/src/main.c
@@ -257,23 +257,27 @@ int main(int argc, char *argv[])
     u32 upd_ver = get_updater_version(model == 4);
 
 	/* make sure that we are not attempting to downgrade a PSP below its firmware boundaries */
+	
     if ((baryon == 0x00403000) && (upd_ver < 0x660)) {
         printf("This app does not support downgrading a PSP 11g below 6.60.\n");
         ErrorExit(5000, "Exiting in 5 seconds.\n");
-    }
-	/* downgrading a 09g to fw 6.20 is an exception, otherwise would be <0x630 */
-	else if ((baryon == 0x002E4000) && (upd_ver < 0x620)) {
-        printf("This app does not support downgrading a PSP 09g below 6.20.\n");
+    } /* Disabled functionality to downgrade 09g to 6.20, otherwise would be <0x620 */
+	else if ((baryon == 0x002E4000) && (upd_ver < 0x630)) {
+        printf("This app does not support downgrading a PSP 09g below 6.30.\n");
         ErrorExit(5000, "Exiting in 5 seconds.\n");
-    }	
+    }
 	else if ((baryon == 0x012E4000) && (upd_ver < 0x630)) {
         printf("This app does not support downgrading a PSP 07g below 6.30.\n");
         ErrorExit(5000, "Exiting in 5 seconds.\n");
-    }	/* baryon check for TA-091/093; model check is done for the rare PSPgo TA-094 board (its baryon value is unknown) */
-	else if (((baryon == 0x00304000) || (baryon == 0x002C4000) || (model == 4)) && (upd_ver < 0x570)) {
-        printf("This app does not support downgrading a PSP 04g or 05g below 5.70.\n");
+    }	/* baryon check for TA-091, model check is done for the rare PSPgo TA-094 board (its baryon value is unknown) */
+	else if (((baryon == 0x00304000) || (model == 4)) && (upd_ver < 0x570)) {
+        printf("This app does not support downgrading a PSP 05g below 5.70.\n");
         ErrorExit(5000, "Exiting in 5 seconds.\n");
     }
+	else if ((baryon == 0x002C4000) && (upd_ver < 0x570)) {
+        printf("This app does not support downgrading a PSP 04g below 5.70.\n");
+        ErrorExit(5000, "Exiting in 5 seconds.\n");
+    }	
 	else if (((baryon == 0x00285000) || (baryon == 0x00263100)) && (upd_ver < 0x420)) {
         printf("This app does not support downgrading a PSP 03g below 4.20.\n");
         ErrorExit(5000, "Exiting in 5 seconds.\n");
@@ -286,75 +290,6 @@ int main(int argc, char *argv[])
         printf("This app does not support downgrading a TA-082/086 PSP 01g below 2.00.\n");
         ErrorExit(5000, "Exiting in 5 seconds.\n");
     }
-
-	/* DOESNT FULLY WORK YET */
-	/* ok, now get the idstorage value */
-	u8 device_fw_ver[4];
-	int res2 = 0; //sceIdStorageLookup(0x51, 0, device_fw_ver, 4);	//correct function, but crashes the Homebrew
-	u32 min_ver = 0;
-		
-	/* check for error */
-	if (res2 < 0)
-	{	
-		/* if the factory fw is unknown, set min_ver to 1.00 instead
-		   this is normal on 01g, but usually an IDStorage issue on 02g+ devices */
-		min_ver = 0x100;
-	}
-	else
-	{
-		/* convert to hex */
-		min_ver = (((device_fw_ver[0] - '0') & 0xF) << 8) | (((device_fw_ver[2] - '0') & 0xF) << 4) | (((device_fw_ver[3] - '0') & 0xF) << 0);
-	}
-	
-	if (upd_ver < min_ver)
-	{
-        printf("\n" "The target firmware %x.%x is lower than your factory firmware %x.%x", (upd_ver >> 8) & 0xF, upd_ver & 0xFF, (min_ver >> 8) & 0xF, min_ver & 0xFF);
-		printf("\n" "and reflashing is slightly more risky. Proceed? (X = Yes, R = No)\n");
-        while (1)
-        {
-            sceCtrlPeekBufferPositive(&pad_data, 1);
-            
-            /* filter out previous buttons  */
-            cur_buttons = pad_data.Buttons & ~prev_buttons;
-            prev_buttons = pad_data.Buttons;
-            
-            /* check for cross */
-            if (cur_buttons & PSP_CTRL_CROSS)
-            {
-                break;
-            }
-            
-            else if (cur_buttons & PSP_CTRL_RTRIGGER)
-            {
-                ErrorExit(5000, "Exiting in 5 seconds.\n");
-            }
-        }
-	}
-		
-	if (min_ver == 0x100 && model != 0)
-	{
-        printf("\n" "Your PSP's factory firmware is unknown and the target firmware %x.%x", (upd_ver >> 8) & 0xF, upd_ver & 0xFF);
-		printf("\n" "might be lower than it, therefore reflashing is slightly more risky.Proceed? (X = Yes, R = No)\n");
-        while (1)
-        {
-            sceCtrlPeekBufferPositive(&pad_data, 1);
-            
-            /* filter out previous buttons */
-            cur_buttons = pad_data.Buttons & ~prev_buttons;
-            prev_buttons = pad_data.Buttons;
-            
-            /* check for cross */
-            if (cur_buttons & PSP_CTRL_CROSS)
-            {
-                break;
-            }
-            
-            else if (cur_buttons & PSP_CTRL_RTRIGGER)
-            {
-                ErrorExit(5000, "Exiting in 5 seconds.\n");
-            }
-        }		
-	}
 	
     
     /* check for 09g or 07g, we treat this as a 04g */

--- a/src/main.c
+++ b/src/main.c
@@ -211,6 +211,16 @@ int main(int argc, char *argv[])
     
     /* display model */
     printf("Your PSP reports model %02ig.\n", model+1);
+
+    
+    /* check if real != true */
+    if (true_model != model)
+    {
+        /* display */
+        printf("Your PSP is originally a %02ig model.\n", true_model + 1);
+        ErrorExit(10000, "Due to the experimental nature of the whole 09g to 04g downgrade, functionality to change firmware is prohibited through this program.");
+    }
+	
 	/* delay the thread */
     sceKernelDelayThread(1 * 1000 * 1000);
 	/*extra disclaimer for 07g devices, as support for them has been barely tested
@@ -238,15 +248,7 @@ int main(int argc, char *argv[])
                 ErrorExit(5000, "Exiting in 5 seconds.\n");
             }
         }
-    }
-    
-    /* check if real != true */
-    if (true_model != model)
-    {
-        /* display */
-        printf("Your PSP is originally a %02ig model.\n", true_model + 1);
-        ErrorExit(10000, "Due to the experimental nature of the whole 09g to 04g downgrade, functionality to change firmware is prohibited through this program.");
-    }
+    }	
     
     /* delay the thread */
     sceKernelDelayThread(4*1000*1000);
@@ -263,7 +265,7 @@ int main(int argc, char *argv[])
         model != 2 &&            /* PSP 3000 */
         model != 3 &&            /* PSP 4000/7000/9000 */
         model != 4 &&            /* PSP Go */
-        model != 10            /* PSP E1000 (Street) */
+        model != 10              /* PSP E1000 (Street) */
     )
     {
         /* unsupported */

--- a/src/main.c
+++ b/src/main.c
@@ -224,7 +224,7 @@ int main(int argc, char *argv[])
     sceKernelDelayThread(5*1000*1000);
     
     /* check for 09g, we treat this as a 04g */
-    if(model == 8)
+    if(model == 8 || model == 6) //also treat 07g as a 04g
     {
         model = 3;
     }
@@ -233,7 +233,7 @@ int main(int argc, char *argv[])
     if (model != 0 &&            /* PSP PHAT */
         model != 1 &&            /* PSP SLIM */
         model != 2 &&            /* PSP 3000 */
-        model != 3 &&            /* PSP 4000 */
+        model != 3 &&            /* PSP 4000/7000/9000 */
         model != 4 &&            /* PSPgo */
         model != 10            /* PSP E-1000 (Street) */
     )

--- a/src/main.c
+++ b/src/main.c
@@ -262,8 +262,8 @@ int main(int argc, char *argv[])
         model != 1 &&            /* PSP SLIM */
         model != 2 &&            /* PSP 3000 */
         model != 3 &&            /* PSP 4000/7000/9000 */
-        model != 4 &&            /* PSPgo */
-        model != 10            /* PSP E-1000 (Street) */
+        model != 4 &&            /* PSP Go */
+        model != 10            /* PSP E1000 (Street) */
     )
     {
         /* unsupported */

--- a/src/main.c
+++ b/src/main.c
@@ -211,7 +211,8 @@ int main(int argc, char *argv[])
     
     /* display model */
     printf("Your PSP reports model %02ig.\n", model+1);
-
+	/* delay the thread */
+    sceKernelDelayThread(1 * 1000 * 1000);
 	/*extra disclaimer for 07g devices, as support for them has been barely tested
 	  theoretically they should be fully supported for fws 6.30 to 6.6x*/
 	if (model == 6)
@@ -248,7 +249,7 @@ int main(int argc, char *argv[])
     }
     
     /* delay the thread */
-    sceKernelDelayThread(5*1000*1000);
+    sceKernelDelayThread(4*1000*1000);
     
     /* check for 09g or 07g, we treat this as a 04g */
     if(model == 8 || model == 6)

--- a/src/main.c
+++ b/src/main.c
@@ -28,7 +28,7 @@ PSP_MODULE_INFO("Chronoswitch", 0, 1, 1);
 PSP_MAIN_THREAD_ATTR(PSP_THREAD_ATTR_VFPU);
 PSP_HEAP_SIZE_KB(3 << 10);
 
-#define DOWNGRADER_VER    ("7.0")
+#define DOWNGRADER_VER    ("7.1")
 
 typedef struct __attribute__((packed))
 {
@@ -211,6 +211,33 @@ int main(int argc, char *argv[])
     
     /* display model */
     printf("Your PSP reports model %02ig.\n", model+1);
+
+	/*extra disclaimer for 07g devices, as support for them has been barely tested
+	  theoretically they should be fully supported for fws 6.30 to 6.6x*/
+	if (model == 6)
+    {
+        printf("\n" "Your PSP reports model %02ig and reflashing is slightly more risky.\n", model+1);
+		printf("Proceed? (X = Yes, R = No)\n");
+        while (1)
+        {
+            sceCtrlPeekBufferPositive(&pad_data, 1);
+            
+            /* filter out previous buttons */
+            cur_buttons = pad_data.Buttons & ~prev_buttons;
+            prev_buttons = pad_data.Buttons;
+            
+            /* check for cross */
+            if (cur_buttons & PSP_CTRL_CROSS)
+            {
+                break;
+            }
+            
+            else if (cur_buttons & PSP_CTRL_RTRIGGER)
+            {
+                ErrorExit(5000, "Exiting in 5 seconds.\n");
+            }
+        }
+    }
     
     /* check if real != true */
     if (true_model != model)
@@ -223,8 +250,8 @@ int main(int argc, char *argv[])
     /* delay the thread */
     sceKernelDelayThread(5*1000*1000);
     
-    /* check for 09g, we treat this as a 04g */
-    if(model == 8 || model == 6) //also treat 07g as a 04g
+    /* check for 09g or 07g, we treat this as a 04g */
+    if(model == 8 || model == 6)
     {
         model = 3;
     }


### PR DESCRIPTION
Version 7.2:
- Removed 'factory firmware limitation', which prevented certain PSPs from being downgradable at all or limited them from being downgraded to certain firmwares they theoretically support.
- Chronoswitch now detects your PSP's motherboard alongside its model and allows flashing all firmwares (5.00+) that are supported by it.
- Removed support for downgrading 09g units below 6.30.

Version 7.1:
- Added experimental support for 07g units on 6.6x.